### PR TITLE
allow octane version 1.*

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "license": "MIT",
     "homepage": "https://github.com/tideways/laravel-octane-middleware",
     "require": {
-        "laravel/octane": ">=0.1.0,<1.0"
+        "laravel/octane": ">=0.1.0,<2.0"
     },
     "autoload": {
         "psr-4": {"Tideways\\LaravelOctane\\": "src/"}


### PR DESCRIPTION
currently, we only allow the pre-release versions of laravel/octane

fixes #2 