### PR TITLE
Fix profiling by Chrome extension

### DIFF
--- a/src/OctaneMiddleware.php
+++ b/src/OctaneMiddleware.php
@@ -27,7 +27,7 @@ class OctaneMiddleware
         } else if ($request->headers->has('X-TIDEWAYS-PROFILER')) {
             $developerSession = $request->headers->get('X-TIDEWAYS-PROFILER');
         } else if ($request->cookies->has('TIDEWAYS_SESSION')) {
-            $developerSession = $request->cookies->get('TIDEWAYS_SESSION')->getValue();
+            $developerSession = $request->cookies->get('TIDEWAYS_SESSION');
         }
 
         $service = ini_get('tideways.service') ?: 'web';


### PR DESCRIPTION
When I try to run a profile using the Chrome extension I get the following error: `Call to a member function getValue() on string` (https://user-images.githubusercontent.com/6287961/142187497-0202f57b-0799-427a-8d36-472ad325368e.png)

As a cookie will always return a string, we can simply drop the `getValue`.
