### PR TITLE
Call markAsWebTransaction if available, added in 5.5.8 in early 2022.

### DIFF
--- a/src/OctaneMiddleware.php
+++ b/src/OctaneMiddleware.php
@@ -37,6 +37,10 @@ class OctaneMiddleware
         \Tideways\Profiler::setCustomVariable('http.method', $request->getMethod());
         \Tideways\Profiler::setCustomVariable('http.url', $request->getPathInfo());
 
+        if (class_exists('Tideways\Profiler', 'markAsWebTransaction')) {
+            \Tideways\Profiler::markAsWebTransaction();
+        }
+
         $referenceId = $request->query->get('_tideways_ref', $request->headers->get('X-Tideways-Ref'));
         if ($request->cookies->has('TIDEWAYS_REF')) {
             $referenceId = $request->cookies->get('TIDEWAYS_REF')->getValue();


### PR DESCRIPTION
This makes sure transactions running in Octane are assigned to regular "web" or "app" service instead of their CLI-subservice counterpart. See

https://support.tideways.com/documentation/setup/configuration/services.html#mark-for-web-context