### PR TITLE
Fix `markAsWebTransaction` check

### DIFF
--- a/src/OctaneMiddleware.php
+++ b/src/OctaneMiddleware.php
@@ -38,7 +38,7 @@ class OctaneMiddleware
         \Tideways\Profiler::setCustomVariable('http.method', $request->getMethod());
         \Tideways\Profiler::setCustomVariable('http.url', $request->getPathInfo());
 
-        if (class_exists('Tideways\Profiler', 'markAsWebTransaction')) {
+        if (method_exists('Tideways\Profiler', 'markAsWebTransaction')) {
             \Tideways\Profiler::markAsWebTransaction();
         }
 


### PR DESCRIPTION
I'm using this class as a basis for a middleware for https://github.com/Baldinof/roadrunner-bundle.
I guess you meant `method_exists` instead of `class_exists`.