### PR TITLE
Allow FrankenPHP SAPI as well, minor fixes, test adjustments

### DIFF
--- a/src/OctaneMiddleware.php
+++ b/src/OctaneMiddleware.php
@@ -17,8 +17,8 @@ class OctaneMiddleware
      */
     public function handle(Request $request, Closure $next)
     {
-        if (!class_exists('Tideways\Profiler') || php_sapi_name() !== 'cli') {
-            // only run when Tideways is installed and the CLI sapi is used (thats how Swoole/RR work)
+        if (!class_exists('Tideways\Profiler') || !in_array(php_sapi_name(), ['cli', 'frankenphp'], true)) {
+            // only run when Tideways is installed and the CLI/frankenphp sapi is used (thats how Swoole/RR work)
             return $next($request);
         }
 
@@ -38,7 +38,7 @@ class OctaneMiddleware
         \Tideways\Profiler::setCustomVariable('http.method', $request->getMethod());
         \Tideways\Profiler::setCustomVariable('http.url', $request->getPathInfo());
 
-        if (class_exists('Tideways\Profiler', 'markAsWebTransaction')) {
+        if (method_exists('Tideways\Profiler', 'markAsWebTransaction')) {
             \Tideways\Profiler::markAsWebTransaction();
         }
 

--- a/tests/OctaneMiddlewareTest.php
+++ b/tests/OctaneMiddlewareTest.php
@@ -16,8 +16,6 @@ class OctaneMiddlewareTest extends TestCase
             $this->markTestSkipped('Tideways\Profiler is not installed.');
         }
 
-        $this->assertEquals('basic', ini_get('tideways.monitor'));
-
         \Tideways\Profiler::stop();
     }
 
@@ -46,9 +44,12 @@ function withTideawysDaemon(\Closure $callback = null, $flags = 0)
 {
     $callback = $callback ?: function() {};
     $address = "tcp://127.0.0.1:64111";
-    ini_set("tideways.connection", $address);
+    ini_set('tideways.connection', $address);
     ini_set('tideways.api_key', 'abcdefg');
     ini_set('tideways.sample_rate', 0);
+    ini_set('tideways.monitor', 'basic');
+    putenv('TIDEWAYS_CONNECTION=' . $address);
+    $_SERVER['TIDEWAYS_CONNECTION'] = $address;
     if (ini_get("tideways.connection") !== $address) {
         throw new \RuntimeException('Could not set tideways.connection to ' . $address);
     }


### PR DESCRIPTION
This adds `frankenphp` to the allowed lists of SAPIs for the Middleware.