### PR TITLE
Fix tests for recent extension versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,7 @@
         "psr-4": {"Tideways\\LaravelOctane\\": "src/"}
     },
     "require-dev": {
-        "phpunit/phpunit": "^10.5"
+        "phpunit/phpunit": "^10.5",
+        "symfony/process": "^6.4"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a2fee70cae1308a98599b62d1b3fccec",
+    "content-hash": "6e99ac8f5893c57e961242e0d84a0e07",
     "packages": [
         {
             "name": "brick/math",
@@ -4287,16 +4287,16 @@
         },
         {
             "name": "symfony/process",
-            "version": "v6.4.2",
+            "version": "v6.4.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "c4b1ef0bc80533d87a2e969806172f1c2a980241"
+                "reference": "25214adbb0996d18112548de20c281be9f27279f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/c4b1ef0bc80533d87a2e969806172f1c2a980241",
-                "reference": "c4b1ef0bc80533d87a2e969806172f1c2a980241",
+                "url": "https://api.github.com/repos/symfony/process/zipball/25214adbb0996d18112548de20c281be9f27279f",
+                "reference": "25214adbb0996d18112548de20c281be9f27279f",
                 "shasum": ""
             },
             "require": {
@@ -4328,7 +4328,7 @@
             "description": "Executes commands in sub-processes",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/process/tree/v6.4.2"
+                "source": "https://github.com/symfony/process/tree/v6.4.14"
             },
             "funding": [
                 {
@@ -4344,7 +4344,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-12-22T16:42:54+00:00"
+            "time": "2024-11-06T09:25:01+00:00"
         },
         {
             "name": "symfony/psr-http-message-bridge",
@@ -6914,5 +6914,5 @@
         "php": "^8.0"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/tests/daemon.inc
+++ b/tests/daemon.inc
@@ -1,0 +1,41 @@
+<?php
+
+if (PHP_SAPI !== 'cli') {
+    http_response_code(400);
+
+    exit;
+}
+
+if ($_SERVER['argc'] < 2) {
+    fwrite(STDERR, sprintf("Usage: %s <socket_to_bind>\n", $_SERVER['argv'][0]));
+    exit(1);
+}
+
+$server = @stream_socket_server($_SERVER['argv'][1]);
+
+for (;;) {
+    $socket = stream_socket_accept($server, 5);
+    if (!$socket) {
+        fwrite(STDERR, "Unable to accept connection\n");
+        exit(1);
+    }
+
+    $response = '';
+    do {
+        $response .= fread($socket, 65355);
+    } while (!feof($socket));
+
+    fclose($socket);
+
+    $data = json_decode($response, true);
+
+    // Ignore everything except traces.
+    if (isset($data['type']) && $data['type'] !== 't2') {
+        continue;
+    }
+
+    echo json_encode($data['payload']);
+
+    fclose($server);
+    exit(0);
+}


### PR DESCRIPTION
Recent versions of the Tideways extension enabled Tracepoints in the CLI by default. This leads to the extension sending the tracepoint request as the very first thing that is sent to the daemon socket.

This leads to a Catch-22 when the daemon socket is bound to the same process: We need to accept the tracepoint request to satisfy it and unblock the process, but we can't accept it, since we are blocked on the response.

Furthermore the Tideways extension will send PHPInfo payloads even when manually handling the lifecycle with `Profiler::start()` and `Profiler::stop()`. This PHPInfo payload will need to be ignored as well.

Fix the tests by running the daemon as a background process. This background daemon will ignore everything, except the trace payload and will then exit.